### PR TITLE
Rough in conversation index (retry)

### DIFF
--- a/app/views/forums/show.html.slim
+++ b/app/views/forums/show.html.slim
@@ -2,5 +2,10 @@ div.page-header
   h1 Forums
 = link_to "New Conversation", new_forum_conversation_path(@forum), class: 'btn btn-primary'
 table.table.table-striped
-  - @forum.conversations.each do |c|
-    | <tr id="conversation_#{c.id}"><td>#{c.title}</td></tr>
+    tbody 
+      - @forum.conversations.each do |c|
+        tr id="conversation_#{c.id}"
+          td =' link_to(c.title, conversation_comments_path(c))
+          td =' pluralize(c.comments.count, "Comment") 
+          -if c.comments.any?
+            td =' c.comments.first.created_at.strftime("%m/%d/%Y")

--- a/features/conversations/conversations.feature
+++ b/features/conversations/conversations.feature
@@ -26,6 +26,22 @@ Feature: Conversations
     When I visit the conversation comments page
     Then I should see the comment content on the page
   
+  Scenario: Show an existing conversation in a forum
+  	Given a forum and a conversation
+  	When I visit the forum show page
+  	Then I should see the conversation on the forum's show page
+  	And I should see a link to the conversation's show page
   
+  Scenario: Show the number of comments for a conversation
+  	Given a forum and a conversation with 10 comments
+  	When I visit the forum show page
+  	Then The comment count for the conversation should be 10
+	And I should see the date of the conversation's most recent comment
+  
+  Scenario: Show the date of the most recent comment for a conversation
+  	Given a forum and a conversation with 1 comment
+  	When I visit the forum show page
+  	Then I should see the date of the conversation's most recent comment
 
-  
+
+

--- a/features/step_definitions/conversations_steps.rb
+++ b/features/step_definitions/conversations_steps.rb
@@ -14,6 +14,15 @@ Given /^a conversation with a comment$/ do
   @comment = create(:comment, conversation: @conversation)
 end
 
+Given /^a forum and a conversation with (\d+) comments?$/ do |count|
+  @forum = create(:forum)
+  @conversation = create(:conversation, forum: @forum)
+  count.to_i.times do 
+    create(:comment, conversation: @conversation)
+  end
+  @comment = @conversation.comments.first
+end
+
 #
 # When Steps
 #
@@ -55,5 +64,24 @@ end
 Then /^I should see the comment content on the page$/ do
   within("#comment_#{@comment.id}") do
     page.should have_content @comment.content
+  end
+end
+
+Then /^I should see a link to the conversation's show page$/ do
+  within("#conversation_#{@conversation.id}") do
+    page.should have_link @conversation.title
+  end
+end
+
+
+Then /^The comment count for the conversation should be (\d+)$/ do |count|
+  within("#conversation_#{@conversation.id}") do
+    page.should have_content count
+  end
+end
+
+Then /^I should see the date of the conversation's most recent comment$/ do
+  within("#conversation_#{@conversation.id}") do
+    page.should have_content @comment.created_at.strftime("%m/%d/%Y")
   end
 end


### PR DESCRIPTION
The forum#show page should render a link to each conversation with the number of comments and the latest comment date.
