### PR TITLE
Comment order scope should be it's default_scope

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,6 +5,6 @@ class Comment < ActiveRecord::Base
   attr_accessible :conversation_id, :user_id, :content
   validates_presence_of :user, :conversation
 
-  scope :order, "created_at ASC"
+  default_scope order("created_at ASC")
 
 end


### PR DESCRIPTION
We don't seem to use an order scope anywhere.  I think that was supposed to be the default_scope (for Conversation#original_author).
