### PR TITLE
Added sorting to conversations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'email_spec'
+  gem 'timecop'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
       libv8 (~> 3.3.10)
     thor (0.14.6)
     tilt (1.3.3)
+    timecop (0.5.2)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
@@ -298,6 +299,7 @@ DEPENDENCIES
   slim
   slim-rails
   sqlite3
+  timecop
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)
   unicorn

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,7 @@
 class Comment < ActiveRecord::Base
   belongs_to :user
-  belongs_to :conversation
+  belongs_to :conversation,
+    touch: true
 
   attr_accessible :conversation_id, :user_id, :content
   validates_presence_of :user, :conversation

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,6 +6,8 @@ class Conversation < ActiveRecord::Base
 
   attr_accessible :title, :forum_id
   validates_presence_of :forum, :title, :creator
+  
+  default_scope order('updated_at DESC')
 
   def original_author
     creator

--- a/db/migrate/20120925225547_add_timestamps_to_conversation.rb
+++ b/db/migrate/20120925225547_add_timestamps_to_conversation.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToConversation < ActiveRecord::Migration
+  def change
+    add_timestamps(:conversations)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120925023432) do
+ActiveRecord::Schema.define(:version => 20120925225547) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -40,9 +40,11 @@ ActiveRecord::Schema.define(:version => 20120925023432) do
   add_index "comments", ["conversation_id"], :name => "index_comments_on_conversation_id"
 
   create_table "conversations", :force => true do |t|
-    t.string  "title"
-    t.integer "forum_id"
-    t.integer "creator_id"
+    t.string   "title"
+    t.integer  "forum_id"
+    t.integer  "creator_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "conversations", ["creator_id"], :name => "index_conversations_on_creator_id"

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1,50 +1,75 @@
 require 'spec_helper'
 
 describe Conversation do
-  before do
-    @conversation = create(:conversation)
-  end
-
-  it "should be valid" do
-    @conversation.valid?.should be_true
-  end
-
-  describe "associations" do
-    it "should know about any related Comments" do
-      @conversation.comments.should == []
-    end
-  end
-
-  describe "validations" do
-    it "should require a Forum" do
-      @conversation.forum = nil
-      @conversation.valid?.should be_false
-    end
-  end
-
-  describe "accessible attributes" do
-    it "should allow :title" do
-      new_title = "Something Else"
-      @conversation.update_attributes({:title => new_title})
-      @conversation.title.should == new_title
+  context "General Model Methods" do
+    before do
+      @conversation = create(:conversation)
     end
 
-    it "should allow :forum_id" do
-      forum = create(:forum)
-      @conversation.update_attributes({:forum_id => forum.id})
-      @conversation.forum.should == forum
+    it "should be valid" do
+      @conversation.valid?.should be_true
+    end
+
+    describe "associations" do
+      it "should know about any related Comments" do
+        @conversation.comments.should == []
+      end
+    end
+
+    describe "validations" do
+      it "should require a Forum" do
+        @conversation.forum = nil
+        @conversation.valid?.should be_false
+      end
+    end
+
+    describe "accessible attributes" do
+      it "should allow :title" do
+        new_title = "Something Else"
+        @conversation.update_attributes({:title => new_title})
+        @conversation.title.should == new_title
+      end
+
+      it "should allow :forum_id" do
+        forum = create(:forum)
+        @conversation.update_attributes({:forum_id => forum.id})
+        @conversation.forum.should == forum
+      end
+    end
+    it "should know about its original author" do
+      u1 = create(:user)     
+      u2 = create(:user) 
+      conversation = create(:conversation, :creator => u1)  
+      c1 = create(:comment, :user => u1, conversation: conversation)     
+      c2 = create(:comment, :user => u2, conversation: conversation)     
+      conversation.original_author.should == u1
+    end
+
+    it "original author should be a User" do
+      @conversation.original_author.should be_a(User)
     end
   end
-  it "should know about its original author" do
-    u1 = create(:user)     
-    u2 = create(:user) 
-    conversation = create(:conversation, :creator => u1)  
-    c1 = create(:comment, :user => u1, conversation: conversation)     
-    c2 = create(:comment, :user => u2, conversation: conversation)     
-    conversation.original_author.should == u1
-  end
-
-  it "original author should be a User" do
-    @conversation.original_author.should be_a(User)
+  context 'sorting' do
+    before do
+      start_time = Time.local(2012, 01, 01, 8, 0)
+      Timecop.freeze(start_time)
+      @c1 = create(:conversation)
+      later = Time.local(2012, 01, 01, 8, 5) # 8:05 Jan 1
+      Timecop.freeze(later)
+      @c2 = create(:conversation)
+    end
+    
+    it "should order the conversations by their updated_at" do
+      Conversation.all.should eq [@c2, @c1]
+    end
+    
+    it "creating a new post will change the order" do
+      even_later = Time.local(2012, 01, 01, 9, 0)
+      create(:comment, conversation: @c1)
+      Conversation.all.should eq [@c1, @c2]
+    end
+    after do
+      Timecop.return
+    end
   end
 end


### PR DESCRIPTION
In preparation of implementing stickying, I've added a updated_at default scope to the conversations.

This does a few things
1. Conversations now have timestamps
2. Conversations are ordered by updated_at
3. Comments `touch` conversations
4. Timecop is now in the test group
