### PR TITLE
Created Counter Cache for Conversations

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,8 @@
 class Comment < ActiveRecord::Base
   belongs_to :user
   belongs_to :conversation,
-    touch: true
+    touch: true,
+    counter_cache: true
 
   attr_accessible :conversation_id, :user_id, :content
   validates_presence_of :user, :conversation

--- a/app/views/forums/show.html.slim
+++ b/app/views/forums/show.html.slim
@@ -7,6 +7,6 @@ table.table.table-striped
       - @forum.conversations.each do |c|
         tr id="conversation_#{c.id}"
           td =' link_to(c.title, conversation_comments_path(c))
-          td =' pluralize(c.comments.count, "Comment") 
+          td =' pluralize(c.comments_count, "Comment") 
           -if c.comments.any?
-            td =' c.comments.last.created_at.strftime("%m/%d/%Y")
+            td =' c.updated_at.strftime("%m/%d/%Y")

--- a/db/migrate/20120926125509_add_comment_counter_cache_to_conversations.rb
+++ b/db/migrate/20120926125509_add_comment_counter_cache_to_conversations.rb
@@ -1,0 +1,12 @@
+class AddCommentCounterCacheToConversations < ActiveRecord::Migration
+  def up
+    add_column :conversations, :comments_count, :integer, default: 0
+    Conversation.reset_column_information
+    Conversation.find_each do |c|
+      Conversation.update_counters c.id, comments_count: c.comments.count
+    end
+  end
+  def down
+    remove_column :conversations, :comments_count
+  end
+end

--- a/db/migrate/20120926133429_add_fake_timestamps_to_conversations.rb
+++ b/db/migrate/20120926133429_add_fake_timestamps_to_conversations.rb
@@ -1,0 +1,7 @@
+class AddFakeTimestampsToConversations < ActiveRecord::Migration
+  # There is no down migration, it's be impossible to track
+  def up
+    Conversation.where(created_at: nil).update_all(created_at: Time.now)
+    Conversation.where(updated_at: nil).update_all(updated_at: Time.now)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120926125509) do
+ActiveRecord::Schema.define(:version => 20120926133429) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120925225547) do
+ActiveRecord::Schema.define(:version => 20120926125509) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(:version => 20120925225547) do
     t.integer  "creator_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "comments_count", :default => 0
   end
 
   add_index "conversations", ["creator_id"], :name => "index_conversations_on_creator_id"

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -72,4 +72,21 @@ describe Conversation do
       Timecop.return
     end
   end
+
+  context 'comments counter' do
+    before do
+      @conversation = create(:conversation)
+    end
+
+    it 'counter cache should increment when a comment is added' do
+      original_comments_count = @conversation.comments_count
+      create(:comment, conversation: @conversation)
+      Conversation.find(@conversation.id).comments_count.should eq (original_comments_count + 1)
+    end
+
+    it 'counter cache should decrement when a comment is destroyed' do
+      Conversation.find(@conversation.id).comments.destroy_all
+      Conversation.find(@conversation.id).comments_count.should eq 0
+    end
+  end
 end


### PR DESCRIPTION
Includes a migration to create fake timestamps for conversations with nils for those values from revisions prior to 7bd7100c8d494a350d46c82fc1e447593251667f.
