### PR TITLE
seo friendly url for forums

### DIFF
--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -4,4 +4,8 @@ class Forum < ActiveRecord::Base
 
   attr_accessible :title
 
+  def to_param
+    "#{id}-#{title.parameterize}"
+  end
+
 end

--- a/features/conversations/conversations.feature
+++ b/features/conversations/conversations.feature
@@ -87,7 +87,6 @@ Feature: Conversations
     And I should see a breadcrumb link with the conversation ID
     And I should see a breadcrumb element titled "Reply"
 
-
   @javascript
   Scenario: Submit Quick Reply
     Given a forum and a conversation

--- a/features/forums/forums.feature
+++ b/features/forums/forums.feature
@@ -32,3 +32,8 @@ Feature: Forums
     And I visit the forums index page
     Then I should be signed out
 
+  Scenario: SEO friendly URLS
+    Given a forum called "On Topic"
+    When I visit the forum
+    Then I should see a seo friendly url with "1-on-topic"
+

--- a/features/step_definitions/forums_steps.rb
+++ b/features/step_definitions/forums_steps.rb
@@ -39,4 +39,8 @@ Then /^I should see a breadcrumb element titled "(.+)"$/ do |title|
   within("ul.breadcrumb") do
     page.should have_content title
   end
-end  
+end
+
+Then /^I should see a seo friendly url with "(.+)"$/ do |url|
+  current_path.should == "/forums/#{url}"
+end


### PR DESCRIPTION
Changed the url structure for forums to show the title of the forum instead of just the id.

Also my first ever pull request!

If this is correct and done properly I will also do this for the conversations.
