### PR TITLE
Fixes Issues with Comment Reply Preview view

### DIFF
--- a/app/views/comments/_comment_preview.html.slim
+++ b/app/views/comments/_comment_preview.html.slim
@@ -1,18 +1,18 @@
 #conversation_comment_preview
-  .row.comment
-    .span2
+  .comment
+    .header-area
       .row
-        .thumbnail
-          = link_to avatar(current_user, size: 200), user_path(current_user)
-          = link_to current_user.email, user_path(current_user)
+        .avatar
+          .span1
+            = link_to avatar(current_user, size: 50), user_path(current_user)
 
-    .span10
-      .row.comment-header
-        .span8
-          p #{Time.now} (#{time_ago_in_words(Time.now)} ago)
+        .meta-area
+          .span8
+            p.name= link_to current_user.email, user_path(current_user)
+            p (#{time_ago_in_words(Time.now)} ago)
+        .span3
 
-        .span2
-          = link_to glyphicon('icon-edit', text: 'Edit'), '#', :class => "btn btn-mini"
-
-      .row
-        #preview-text
+    .row
+      .span12
+        .content
+          #preview-text


### PR DESCRIPTION
**Fixed these issues in Reply Preview**  
- Edit button does not link to anything
- Gravatar is too large
- Email falls below gravatar
- Time format can be improved
- Preview of comment appears right of gravatar instead of below

The preview view now looks nearly identical to how the published comment will look.
