### PR TITLE
better handles index on migration

### DIFF
--- a/db/migrate/20121019161722_rename_conversation_locked.rb
+++ b/db/migrate/20121019161722_rename_conversation_locked.rb
@@ -1,11 +1,11 @@
 class RenameConversationLocked < ActiveRecord::Migration
   def up
     rename_column :conversations, :locked, :closed
-    rename_index :conversations, :locked, :closed
+    add_index :conversations, :closed
   end
 
   def down
-    rename_index :conversations, :closed, :locked
     rename_column :conversations, :closed, :locked
+    add_index :conversations, :locked
   end
 end


### PR DESCRIPTION
If you work on PG in dev mode you'll see something like "this will create an implicit index on COLUMNNAMEHERE". 

I haven't looked inside my remote PG instance, but I'm assuming the index was destroyed as it was dependent to the column name. Added a new index on the new column and it should be working. It did on mine at lest. 

**edit** that's a horrible way to put it. Must work on English.
